### PR TITLE
Add db_api get_table_rows_ex

### DIFF
--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -65,6 +65,11 @@ fc::variants database_api::get_objects(const vector<object_id_type>& ids)const
    return my->get_objects( ids );
 }
 
+get_table_rows_result database_api::get_table_rows_ex(string contract, string table, const get_table_rows_params& params) const
+{
+   return my->get_table_rows_ex(contract, table,params);
+}
+
 get_table_rows_result database_api::get_table_rows(string contract, string table, uint64_t start, uint64_t limit) const
 {
     return my->get_table_rows(contract, table, start, limit);

--- a/libraries/app/database_api.cpp
+++ b/libraries/app/database_api.cpp
@@ -65,9 +65,9 @@ fc::variants database_api::get_objects(const vector<object_id_type>& ids)const
    return my->get_objects( ids );
 }
 
-get_table_rows_result database_api::get_table_rows_ex(string contract, string table, const get_table_rows_params& params) const
+get_table_rows_result database_api::get_table_rows_ex(string contract, string table, const get_table_rows_params &params) const
 {
-   return my->get_table_rows_ex(contract, table,params);
+    return my->get_table_rows_ex(contract, table, params);
 }
 
 get_table_rows_result database_api::get_table_rows(string contract, string table, uint64_t start, uint64_t limit) const

--- a/libraries/app/database_api_impl.cpp
+++ b/libraries/app/database_api_impl.cpp
@@ -124,10 +124,187 @@ fc::variants database_api_impl::get_objects(const vector<object_id_type>& ids)co
 
    return result;
 }
-
+/* un used
 static void copy_inline_row(const key_value_object& obj, vector<char>& data) {
    data.resize( obj.value.size() );
    memcpy( data.data(), obj.value.data(), obj.value.size() );
+}*/ 
+uint64_t get_table_index_name(name tablename, const std::string &index_position, bool& primary) {
+    try {
+        
+        using boost::algorithm::starts_with;
+        // see multi_index packing of index name
+        const uint64_t table = tablename;
+        uint64_t index = table & 0xFFFFFFFFFFFFFFF0ULL;
+
+        FC_ASSERT(index == table, "Unsupported table name: ${n}", ("n", tablename));
+
+        primary = false;
+        uint64_t pos = 0;
+        if (index_position.empty() || index_position == "first" || index_position == "primary" ||
+            index_position == "one") {
+            primary = true;
+        } else if (starts_with(index_position, "sec") || index_position == "two") { // second, secondary
+        } else if (starts_with(index_position, "ter") ||
+                   starts_with(index_position, "th")) { // tertiary, ternary, third, three
+            pos = 1;
+        } else if (starts_with(index_position, "fou")) { // four, fourth
+            pos = 2;
+        } else if (starts_with(index_position, "fi")) { // five, fifth
+            pos = 3;
+        } else if (starts_with(index_position, "six")) { // six, sixth
+            pos = 4;
+        } else if (starts_with(index_position, "sev")) { // seven, seventh
+            pos = 5;
+        } else if (starts_with(index_position, "eig")) { // eight, eighth
+            pos = 6;
+        } else if (starts_with(index_position, "nin")) { // nine, ninth
+            pos = 7;
+        } else if (starts_with(index_position, "ten")) { // ten, tenth
+            pos = 8;
+        } else {
+            try {
+                pos = fc::to_uint64(index_position);
+            } catch (...) {
+                FC_ASSERT(false, "Invalid index_position: ${p}",("p", index_position));
+
+            }
+            if (pos < 2) {
+                primary = true;
+                pos = 0;
+            } else {
+                pos -= 2;
+            }
+        }
+        index |= (pos & 0x000000000000000FULL);
+        return index;
+    }
+    FC_CAPTURE_AND_RETHROW((tablename)(index_position)(primary))
+}
+fc::variants get_table_objects_ex(bool &more, const database &db, const account_object &account_obj, uint64_t table, const get_table_rows_params& params)
+{
+    try {
+        fc::variants result;
+        // check lower_bound and upper_bound
+        FC_ASSERT(params.lower_bound < params.upper_bound ,"lower_bound must < upper_bound");
+        abi_serializer abis(account_obj.abi, fc::milliseconds(10000));
+
+        name tname(table);
+        uint64_t count = 0 ;
+        auto end = fc::time_point::now() + fc::microseconds(1000 * 10);
+
+        bool is_primary = false;
+        uint64_t _index_position = get_table_index_name(tname,params.index_position,is_primary);
+
+        if(is_primary == true){  // get table by primary
+            const auto &table_idx = db.get_index_type<table_id_multi_index>().indices().get<by_code_scope_table>();
+            auto existing_tid = table_idx.find(boost::make_tuple(account_obj.id.instance(), name(account_obj.id.instance()), name(table)));
+            if (existing_tid != table_idx.end()) {
+                // auto num = existing_tid->count; get the data count of table
+                const auto &kv_idx = db.get_index_type<key_value_index>().indices().get<by_scope_primary>();
+                auto lower = kv_idx.lower_bound(boost::make_tuple(existing_tid->id, params.lower_bound));
+                auto upper = kv_idx.lower_bound(boost::make_tuple(existing_tid->id, params.upper_bound));
+
+                auto traver =[&](auto lower,auto upper){
+                    auto it = lower;
+                    for (; it != upper; ++it) {
+                        if (fc::time_point::now() > end || count == params.limit) break;
+                        result.emplace_back(abis.binary_to_variant(tname.to_string(), it->value, fc::microseconds(1000 * 10)));
+                        ++count;
+                    }
+                    if (count<params.limit && it != upper && ++it != upper) {
+                        more = true;
+                    }
+                };
+                auto traver_reverse =[&](auto lower,auto upper){
+                    auto it = upper;        // the itor before of the end
+                    for (; it != lower ;) {
+                        --it;
+                        if (fc::time_point::now() > end || count == params.limit) break;
+                        result.emplace_back(abis.binary_to_variant(tname.to_string(), it->value, fc::microseconds(1000 * 10)));
+                        ++count;
+                    }
+                    if (count<params.limit && it != lower && --it != lower) {
+                        more = true;
+                    }
+                };
+                if(params.reverse && *params.reverse )  // reverse
+                {
+                    traver_reverse(lower,upper);
+                }else{        //  unreverse
+                    traver(lower,upper);
+                }
+            }
+        }else{      // get table by secondary/ternary
+            const auto &table_idx = db.get_index_type<table_id_multi_index>().indices().get<by_code_scope_table>();
+            auto primary_tid = table_idx.find(boost::make_tuple(account_obj.id.instance(), name(account_obj.id.instance()), name(table)));
+            auto sec_tid = table_idx.find(boost::make_tuple(account_obj.id.instance(), name(account_obj.id.instance()), _index_position)); // table name with index
+            if (sec_tid != table_idx.end()) {
+
+                const auto &sec_idx = db.get_index_type<index64_index>().indices().get<by_secondary>();
+                auto sec_lower = sec_idx.lower_bound(boost::make_tuple(sec_tid->id, params.lower_bound, std::numeric_limits<uint64_t>::lowest()));
+                //auto sec_upper = sec_idx.lower_bound(boost::make_tuple(sec_tid->id, params.upper_bound, std::numeric_limits<uint64_t>::max()));
+                auto sec_upper = sec_idx.lower_bound(boost::make_tuple(sec_tid->id, params.upper_bound, std::numeric_limits<uint64_t>::lowest()));
+                auto traver =[&](auto lower,auto upper){
+                  const auto &kv_idx_for_sec = db.get_index_type<key_value_index>().indices().get<by_scope_primary>();
+                  auto sec_it = lower;
+
+                  for(; sec_it != upper; ++sec_it){
+                     if(fc::time_point::now() > end || count == params.limit)
+                           break;
+                     auto itr2 = kv_idx_for_sec.find(boost::make_tuple(primary_tid->id,sec_it->primary_key));
+                     result.emplace_back(abis.binary_to_variant(tname.to_string(), itr2->value, fc::microseconds(1000 * 10)));
+                     ++count;
+                  }
+                  if(count < params.limit && sec_it != upper && ++sec_it != upper) {
+                     more = true;
+                  }
+                };
+                auto traver_reverse =[&](auto lower,auto upper){
+                    const auto &kv_idx_for_sec = db.get_index_type<key_value_index>().indices().get<by_scope_primary>();
+                    auto sec_it = upper;
+
+                    for(; sec_it != lower ;){
+                        --sec_it;
+                        if(fc::time_point::now() > end || count == params.limit)
+                            break;
+                        auto itr2 = kv_idx_for_sec.find(boost::make_tuple(primary_tid->id,sec_it->primary_key));
+                        result.emplace_back(abis.binary_to_variant(tname.to_string(), itr2->value, fc::microseconds(1000 * 10)));
+                        ++count;
+                    }
+                    if(count < params.limit && sec_it != lower && --sec_it != lower) {
+                        more = true;
+                    }
+                };
+                if(params.reverse && *params.reverse )  // reverse
+                {
+                    traver_reverse(sec_lower,sec_upper);
+                }else{        //  unreverse
+                   traver(sec_lower,sec_upper);
+                }
+            }
+        }
+
+        return result;
+    }
+    FC_CAPTURE_AND_RETHROW((account_obj)(table)(params))
+}
+get_table_rows_result database_api_impl::get_table_rows_ex(string contract, string table, const get_table_rows_params& params) const
+{ try {
+	get_table_rows_result result;
+
+    const auto& accounts_idx = _db.get_index_type<account_index>().indices().get<by_name>();
+    const auto& account_itr = accounts_idx.find(contract);
+    if(account_itr == accounts_idx.end()) {
+    	return result;
+    }
+
+    const account_object &account_obj = *account_itr;
+
+    result.rows = ::graphene::app::get_table_objects_ex(result.more, _db, account_obj, name(table).value, params);
+    return result;
+    }
+    FC_CAPTURE_AND_RETHROW((contract)(table))
 }
 
 fc::variants get_table_objects(bool &more, const database &db, const account_object &account_obj, uint64_t table, uint64_t lower_id, uint64_t uppper_id, uint64_t limit)

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -85,6 +85,7 @@ class database_api
        * If any of the provided IDs does not map to an object, a null variant is returned in its position.
        */
       fc::variants get_objects(const vector<object_id_type>& ids)const;
+      get_table_rows_result get_table_rows_ex(string contract, string table,const get_table_rows_params& params) const;
       get_table_rows_result get_table_rows(string contract, string table, uint64_t start=0, uint64_t limit=10) const;
       fc::variants get_table_objects(uint64_t code, uint64_t scope, uint64_t table, uint64_t lower, uint64_t uppper, uint64_t limit) const;
       bytes serialize_contract_call_args(string contract, string method, string json_args) const;
@@ -740,6 +741,7 @@ FC_API(graphene::app::database_api,
    // Objects
    (get_objects)
    (get_table_objects)
+   (get_table_rows_ex)
    (get_table_rows)
    (serialize_contract_call_args)
    (serialize_transaction)

--- a/libraries/app/include/graphene/app/database_api.hpp
+++ b/libraries/app/include/graphene/app/database_api.hpp
@@ -85,7 +85,7 @@ class database_api
        * If any of the provided IDs does not map to an object, a null variant is returned in its position.
        */
       fc::variants get_objects(const vector<object_id_type>& ids)const;
-      get_table_rows_result get_table_rows_ex(string contract, string table,const get_table_rows_params& params) const;
+      get_table_rows_result get_table_rows_ex(string contract, string table, const get_table_rows_params &params) const;
       get_table_rows_result get_table_rows(string contract, string table, uint64_t start=0, uint64_t limit=10) const;
       fc::variants get_table_objects(uint64_t code, uint64_t scope, uint64_t table, uint64_t lower, uint64_t uppper, uint64_t limit) const;
       bytes serialize_contract_call_args(string contract, string method, string json_args) const;

--- a/libraries/app/include/graphene/app/database_api_common.hpp
+++ b/libraries/app/include/graphene/app/database_api_common.hpp
@@ -38,9 +38,26 @@ struct get_table_rows_result {
    vector<fc::variant> rows;
    bool                more = false;
 };
+struct get_table_rows_params {
+   //bool        json = false;
+   //name        code;
+   //string      scope;
+   //name        table;
+   //string      table_key;
+   uint64_t      lower_bound = 0;
+   uint64_t      upper_bound = -1;  // 0xFFFFFFFFFFFFFFFF
+   uint32_t      limit = 10;
+   //string      key_type;  // type of key specified by index_position
+   std::string   index_position = "1"; // 1 - primary (first), 2 - secondary index (in order defined by multi_index), 3 - third index, etc
+   //string      encode_type{"dec"}; //dec, hex , default=dec
+   optional<bool>  reverse = false;
+   //optional<bool>  show_payer; // show RAM pyer
+};
 
 }} //
 
 FC_REFLECT( graphene::app::order, (price)(quote)(base) );
 FC_REFLECT( graphene::app::get_table_rows_result, (rows)(more) );
+FC_REFLECT( graphene::app::get_table_rows_params, (lower_bound)(upper_bound)(limit)(index_position)(reverse));
+
 

--- a/libraries/app/include/graphene/app/database_api_common.hpp
+++ b/libraries/app/include/graphene/app/database_api_common.hpp
@@ -39,21 +39,12 @@ struct get_table_rows_result {
    bool                more = false;
 };
 struct get_table_rows_params {
-   //bool        json = false;
-   //name        code;
-   //string      scope;
-   //name        table;
-   //string      table_key;
-   uint64_t      lower_bound = 0;
-   uint64_t      upper_bound = -1;  // 0xFFFFFFFFFFFFFFFF
-   uint32_t      limit = 10;
-   //string      key_type;  // type of key specified by index_position
-   std::string   index_position = "1"; // 1 - primary (first), 2 - secondary index (in order defined by multi_index), 3 - third index, etc
-   //string      encode_type{"dec"}; //dec, hex , default=dec
-   optional<bool>  reverse = false;
-   //optional<bool>  show_payer; // show RAM pyer
+    uint64_t lower_bound = 0;
+    uint64_t upper_bound = -1; // 0xFFFFFFFFFFFFFFFF
+    uint32_t limit = 10;
+    std::string index_position = "1"; // 1 - primary (first), 2 - secondary index (in order defined by multi_index), 3 - third index, etc
+    optional<bool> reverse = false;
 };
-
 }} //
 
 FC_REFLECT( graphene::app::order, (price)(quote)(base) );

--- a/libraries/app/include/graphene/app/database_api_impl.hpp
+++ b/libraries/app/include/graphene/app/database_api_impl.hpp
@@ -79,6 +79,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
 
       // Objects
       fc::variants get_objects(const vector<object_id_type>& ids)const;
+      get_table_rows_result get_table_rows_ex(string contract, string table, const get_table_rows_params& params) const;
       get_table_rows_result get_table_rows(string contract, string table, uint64_t start, uint64_t limit=10) const;
       fc::variants get_table_objects(uint64_t code, uint64_t scope, uint64_t table, uint64_t lower, uint64_t uppper, uint64_t limit=10) const;
       bytes serialize_contract_call_args(string contract, string method, string json_args) const;

--- a/libraries/app/include/graphene/app/database_api_impl.hpp
+++ b/libraries/app/include/graphene/app/database_api_impl.hpp
@@ -79,7 +79,7 @@ class database_api_impl : public std::enable_shared_from_this<database_api_impl>
 
       // Objects
       fc::variants get_objects(const vector<object_id_type>& ids)const;
-      get_table_rows_result get_table_rows_ex(string contract, string table, const get_table_rows_params& params) const;
+      get_table_rows_result get_table_rows_ex(string contract, string table, const get_table_rows_params &params) const;
       get_table_rows_result get_table_rows(string contract, string table, uint64_t start, uint64_t limit=10) const;
       fc::variants get_table_objects(uint64_t code, uint64_t scope, uint64_t table, uint64_t lower, uint64_t uppper, uint64_t limit=10) const;
       bytes serialize_contract_call_args(string contract, string method, string json_args) const;

--- a/libraries/wallet/include/graphene/wallet/wallet.hpp
+++ b/libraries/wallet/include/graphene/wallet/wallet.hpp
@@ -1079,7 +1079,16 @@ class wallet_api
        * @returns the table names/types stored in the blockchain
        */
       variant get_contract_tables(string contract) const;
-
+      /** Returns table infos about the given contract.
+       *
+       * @param contract the name of the contract to query
+       * @param table the table of the contract to query
+       * @param start the start primary key of the table primary index
+       * @param limit the max item to return
+       * @param index_type the type of index(primary secondary  )
+       * @returns the table rows stored in the blockchain
+       */
+      get_table_rows_result get_table_rows_ex(string contract, string table, const get_table_rows_params& params) const;
       /** Returns table infos about the given contract.
        *
        * @param contract the name of the contract to query
@@ -2192,6 +2201,7 @@ FC_API( graphene::wallet::wallet_api,
         (update_contract)
         (call_contract)
         (get_contract_tables)
+        (get_table_rows_ex)
         (get_table_rows)
         (register_account2)
         (upgrade_account)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -946,22 +946,25 @@
        {
           _builder_transactions.erase(handle);
        }
-       get_table_rows_result get_table_rows_ex(string contract, string table, const get_table_rows_params& params)
-       { try {
-             FC_ASSERT(params.lower_bound >=0 && params.limit > 0, "lower_bound must >=0 and limit must > 0");
-             account_object contract_obj = get_account(contract);
+       get_table_rows_result get_table_rows_ex(string contract, string table, const get_table_rows_params &params)
+       {
+           try {
+               FC_ASSERT(params.lower_bound >= 0 && params.limit > 0, "lower_bound must >=0 and limit must > 0");
+               account_object contract_obj = get_account(contract);
 
-             const auto& tables = contract_obj.abi.tables;
-             auto iter = std::find_if(tables.begin(), tables.end(),
-                     [&](const table_def& t) { return t.name == table; });
+               const auto &tables = contract_obj.abi.tables;
+               auto iter = std::find_if(tables.begin(), tables.end(),
+                                        [&](const table_def &t) { return t.name == table; });
 
-             if (iter != tables.end()) {
-                 return _remote_db->get_table_rows_ex(contract, table,params);
-             } else {
-                 GRAPHENE_ASSERT(false, table_not_found_exception, "No table found for ${contract}", ("contract", contract));
-             }
-             return get_table_rows_result();
-       } FC_CAPTURE_AND_RETHROW((contract)(table)) }
+               if (iter != tables.end()) {
+                   return _remote_db->get_table_rows_ex(contract, table, params);
+               } else {
+                   FC_ASSERT(false, "No table found for ${contract}", ("contract", contract));
+               }
+               return get_table_rows_result();
+           }
+           FC_CAPTURE_AND_RETHROW((contract)(table))
+       }
 
        get_table_rows_result get_table_rows(string contract, string table, uint64_t start, uint64_t limit)
        { try {
@@ -4684,7 +4687,7 @@
     {
         return my->get_contract_tables(contract);
     }
-    get_table_rows_result wallet_api::get_table_rows_ex(string contract, string table,const get_table_rows_params& params) const
+    get_table_rows_result wallet_api::get_table_rows_ex(string contract, string table, const get_table_rows_params &params) const
     {
         return my->get_table_rows_ex(contract, table, params);
     }

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -946,6 +946,22 @@
        {
           _builder_transactions.erase(handle);
        }
+       get_table_rows_result get_table_rows_ex(string contract, string table, const get_table_rows_params& params)
+       { try {
+             FC_ASSERT(params.lower_bound >=0 && params.limit > 0, "lower_bound must >=0 and limit must > 0");
+             account_object contract_obj = get_account(contract);
+
+             const auto& tables = contract_obj.abi.tables;
+             auto iter = std::find_if(tables.begin(), tables.end(),
+                     [&](const table_def& t) { return t.name == table; });
+
+             if (iter != tables.end()) {
+                 return _remote_db->get_table_rows_ex(contract, table,params);
+             } else {
+                 GRAPHENE_ASSERT(false, table_not_found_exception, "No table found for ${contract}", ("contract", contract));
+             }
+             return get_table_rows_result();
+       } FC_CAPTURE_AND_RETHROW((contract)(table)) }
 
        get_table_rows_result get_table_rows(string contract, string table, uint64_t start, uint64_t limit)
        { try {
@@ -4668,7 +4684,10 @@
     {
         return my->get_contract_tables(contract);
     }
-
+    get_table_rows_result wallet_api::get_table_rows_ex(string contract, string table,const get_table_rows_params& params) const
+    {
+        return my->get_table_rows_ex(contract, table, params);
+    }
     get_table_rows_result wallet_api::get_table_rows(string contract, string table, uint64_t start, uint64_t limit) const
     {
         return my->get_table_rows(contract, table, start, limit);


### PR DESCRIPTION
#95 get_table_rows_ex 接口建议收集
目前初步实现如下扩展：
1、可以通过多种索引方式返回数据。
2、倒序输出lower_bound ~ upper_bound 范围的项。（注：可以倒序输出table末尾n项）
3、参数修改为结构体，某些字段不提供则使用默认值。