### PR TITLE
Provide much explicit signature verification example

### DIFF
--- a/contracts/examples/redpacket/redpacket.cpp
+++ b/contracts/examples/redpacket/redpacket.cpp
@@ -89,8 +89,11 @@ class redpacket : public contract
 
         // check signature
         std::string s = std::to_string(sender);
-        bool flag = verify_signature(s.c_str(), s.length(), &sig, packet_iter->pub_key.c_str(), packet_iter->pub_key.length());
-        graphene_assert(flag, "signature not valid");
+        checksum256 hash;
+        sha256(s.c_str(),s.length(),&hash);
+        assert_recover_key(&hash, &sig, packet_iter->pub_key.c_str(), packet_iter->pub_key.length());
+        //bool flag = verify_signature(s.c_str(), s.length(), &sig, packet_iter->pub_key.c_str(), packet_iter->pub_key.length());
+        //graphene_assert(flag, "signature not valid");
 
         // check record
         auto record_iter = records.find(issuer_id);


### PR DESCRIPTION
use `assert_recover_key` instead of `verify_signature `