### PR TITLE
fix: fix switch chain bug when apply block wrong

### DIFF
--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -61,7 +61,7 @@ void database::reindex(fc::path data_dir, bool fast_replay)
    auto start = fc::time_point::now();
    const auto last_block_num = last_block->block_num();
    uint32_t flush_point = last_block_num < 10000 ? 0 : last_block_num - 10000;
-   uint32_t undo_point = last_block_num < 50 ? 0 : last_block_num - 50;
+   uint32_t undo_point = last_block_num < 10000 ? 0 : last_block_num - 10000;
 
    std::cerr << "Replaying blocks, starting at " << head_block_num() + 1 << std::endl;
    if( head_block_num() >= undo_point )

--- a/libraries/chain/db_management.cpp
+++ b/libraries/chain/db_management.cpp
@@ -61,7 +61,7 @@ void database::reindex(fc::path data_dir, bool fast_replay)
    auto start = fc::time_point::now();
    const auto last_block_num = last_block->block_num();
    uint32_t flush_point = last_block_num < 10000 ? 0 : last_block_num - 10000;
-   uint32_t undo_point = last_block_num < 10000 ? 0 : last_block_num - 10000;
+   uint32_t undo_point = last_block_num < 50 ? 0 : last_block_num - 50;
 
    std::cerr << "Replaying blocks, starting at " << head_block_num() + 1 << std::endl;
    if( head_block_num() >= undo_point )

--- a/libraries/chain/db_update.cpp
+++ b/libraries/chain/db_update.cpp
@@ -87,23 +87,23 @@ void database::update_global_dynamic_data( const signed_block& b )
       dgp.current_aslot += missed_blocks+1;
    });
 
+   uint32_t head_number;
+   if (_fork_db.head()) {
+       head_number = std::max(_dgp.head_block_number, _fork_db.head()->num);
+   } else {
+       head_number = _dgp.head_block_number;
+   }
+
    if( !(get_node_properties().skip_flags & skip_undo_history_check) )
    {
-      GRAPHENE_ASSERT( _dgp.head_block_number - _dgp.last_irreversible_block_num  < GRAPHENE_MAX_UNDO_HISTORY, undo_database_exception,
+      GRAPHENE_ASSERT( head_number - _dgp.last_irreversible_block_num  < GRAPHENE_MAX_UNDO_HISTORY, undo_database_exception,
                  "The database does not have enough undo history to support a blockchain with so many missed blocks. "
                  "Please add a checkpoint if you would like to continue applying blocks beyond this point.",
                  ("last_irreversible_block_num",_dgp.last_irreversible_block_num)("head", _dgp.head_block_number)
                  ("recently_missed",_dgp.recently_missed_count)("max_undo",GRAPHENE_MAX_UNDO_HISTORY) );
    }
-   
-   uint32_t head_number;
-   if(_fork_db.head()){
-      head_number = std::max(_dgp.head_block_number, _fork_db.head()->num);
-   }else{
-      head_number = _dgp.head_block_number;
-   }
-   _undo_db.set_max_size( head_number - _dgp.last_irreversible_block_num + 1 );
-   _fork_db.set_max_size( head_number - _dgp.last_irreversible_block_num + 1 );
+   _undo_db.set_max_size(head_number - _dgp.last_irreversible_block_num + 1);
+   _fork_db.set_max_size(head_number - _dgp.last_irreversible_block_num + 1);
 }
 
 void database::update_signing_witness(const witness_object& signing_witness, const signed_block& new_block)

--- a/libraries/chain/db_update.cpp
+++ b/libraries/chain/db_update.cpp
@@ -95,9 +95,15 @@ void database::update_global_dynamic_data( const signed_block& b )
                  ("last_irreversible_block_num",_dgp.last_irreversible_block_num)("head", _dgp.head_block_number)
                  ("recently_missed",_dgp.recently_missed_count)("max_undo",GRAPHENE_MAX_UNDO_HISTORY) );
    }
-
-   _undo_db.set_max_size( _dgp.head_block_number - _dgp.last_irreversible_block_num + 1 );
-   _fork_db.set_max_size( _dgp.head_block_number - _dgp.last_irreversible_block_num + 1 );
+   
+   uint32_t head_number;
+   if(_fork_db.head()){
+      head_number = std::max(_dgp.head_block_number, _fork_db.head()->num);
+   }else{
+      head_number = _dgp.head_block_number;
+   }
+   _undo_db.set_max_size( head_number - _dgp.last_irreversible_block_num + 1 );
+   _fork_db.set_max_size( head_number - _dgp.last_irreversible_block_num + 1 );
 }
 
 void database::update_signing_witness(const witness_object& signing_witness, const signed_block& new_block)


### PR DESCRIPTION
问题：由于网络中节点程序版本不一致，造成分叉较长时间后，更换正确的版本依然无法切换到正确的分叉。

**直接原因：长分叉上的区块无法连接到fork_db上，即fork_db被破坏。**

导致fork_db被破坏的原因有两个，以下是详细说明。

![image](https://user-images.githubusercontent.com/34617009/55226281-8f34b180-524f-11e9-841b-afea3b0422fa.png)

假设网络中存在两种版本的节点程序，旧版本程序接收到的`111`高度的区块，无法验证通过，则会造成网络分叉。当旧版本程序节点数小于2/3，则旧版本分叉上的区块一直无法被确认为不可逆区块，可逆的区块会一直堆积在fork_db中，分叉无法合并的错误也是由于fork_db引起的。

原因一：函数set_max_size造成fork_db中的部分可逆区块被删除掉，代码见`db_update.cpp`98行

如上图中，假设短分叉区块为113高度，在接收到长分叉上的区块时，会将短分叉的区块从fork_db中pop出来。此时最新区块号为`110`，逻辑如下：
```
// remove the rest of branches.first from the fork_db, those blocks are invalid
 while( ritr != branches.first.rend() )
 {
     _fork_db.remove( (*ritr)->data.id() );
     ++ritr;
   }
  _fork_db.set_head( branches.second.front() );

  // pop all blocks from the bad fork
  while( head_block_id() != branches.second.back()->data.previous )
       pop_block();

  // restore all blocks from the good fork
   for( auto ritr = branches.second.rbegin(); ritr != branches.second.rend(); ++ritr )
    {
           auto session = _undo_db.start_undo_session();
           apply_block( (*ritr)->data, skip );
           _block_id_to_block.store( new_block.id(), (*ritr)->data );
            session.commit();
     }
    throw *except;
```

以上逻辑发生在切换分叉时，长分叉的区块执行错误，抛出的异常后的处理函数中，错误发生的位置：`apply_block`--->`update_global_dynamic_data` ----> `_fork_db.set_max_size`
调整fork_db的size时，`head_block_id`为110，fork_db的`_head`指针指向113，则导致`100~103`的区块被删除（fork_db中的区块为`100~113`，调整后为`103~113`），当短分叉足够长，造成111高度之前的区块被删除之后，则无法切换到长分叉。

原因2：在重启节点后，存在一个机制，fork_db中存在超过50个区块时，则重启只将最新的50个区块放入到fork_db中，50个区块之前，但是尚未不可逆的部分区块，直接apply执行，不放入fork_db。如上图，如果短分叉的区块高度为160，则100~110区块并未不可逆，但是重启不放入fork_db，导致切换长分叉时，长分叉的区块无法连接过来，继而无法切换分叉。逻辑如下：

```
if( i < undo_point )
   apply_block( *block, skip );     // apply_block 不会将区块放入fork_db
else {
   _undo_db.enable();
    push_block( *block, skip );   // push_block 会将区块放入fork_db
 }
```

修改的代码涉及到区块的同步和重放，还没有经过完善的测试和讨论，需要和大家讨论后再决定。
