### PR TITLE
feat: add ref_block_prefix in get_block

### DIFF
--- a/libraries/chain/include/graphene/chain/protocol/block.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/block.hpp
@@ -60,6 +60,7 @@ namespace graphene { namespace chain {
     {
         signed_block_with_info(const signed_block& block) : signed_block(block) {
             block_id = id();
+            ref_block_prefix = block_id._hash[1];
             signing_key = signee();
             transaction_ids.reserve(transactions.size());
             for (const processed_transaction& tx : transactions) {
@@ -72,6 +73,7 @@ namespace graphene { namespace chain {
         block_id_type block_id;
         public_key_type signing_key;
         vector< transaction_id_type > transaction_ids;
+        uint32_t ref_block_prefix;
     };
 
 } } // graphene::chain
@@ -79,5 +81,5 @@ namespace graphene { namespace chain {
 FC_REFLECT( graphene::chain::block_header, (previous)(timestamp)(witness)(transaction_merkle_root)(extensions) )
 FC_REFLECT_DERIVED( graphene::chain::signed_block_header, (graphene::chain::block_header), (witness_signature) )
 FC_REFLECT_DERIVED( graphene::chain::signed_block, (graphene::chain::signed_block_header), (transactions) )
-FC_REFLECT_DERIVED( graphene::chain::signed_block_with_info, (graphene::chain::signed_block), (block_id)(signing_key)(transaction_ids) )
+FC_REFLECT_DERIVED( graphene::chain::signed_block_with_info, (graphene::chain::signed_block), (block_id)(signing_key)(transaction_ids)(ref_block_prefix) )
 


### PR DESCRIPTION
#144 add ref_block_prefix in get_block.
```
get_block 12842351
{
  "previous": "00c3f56ec7df8d8cf6cd43b505921620198d35f9",
  "timestamp": "2019-04-08T08:45:33",
  "witness": "1.6.40",
  "transaction_merkle_root": "0000000000000000000000000000000000000000",
  "extensions": [],
  "witness_signature": "200e86ac010574695a2a054a4190c1df74af058243dc6475e02d21e96213127a445193bd67da552685271f5e3a6b8ed289cfda469abbfdb17aca854255b8d13a1d",
  "transactions": [],
  "block_id": "00c3f56fa3c79bec85d6b58fe0b0c99416ed3992",
  "signing_key": "GXC78E6evCFFacKPXh93qQDo9fu91nbADBAhCPqGqf5EhdSjhby1b",
  "transaction_ids": [],
  "ref_block_prefix": 3969632163
}
```