### PR TITLE
Modify update contract logic

### DIFF
--- a/libraries/app/database_api_impl.cpp
+++ b/libraries/app/database_api_impl.cpp
@@ -1552,7 +1552,18 @@ vector< fc::variant > database_api_impl::get_required_fees( const vector<operati
            if (op.which() == operation::tag<contract_call_operation>::value) {
                result.push_back(mock_fee);
            } else {
-               result.push_back(helper.set_op_fees(op));
+               if (_db.head_block_time() > HARDFORK_1024_TIME) {
+                   if (op.which() == operation::tag<contract_update_operation>::value) {
+                       auto op_fee = _db.get_update_contract_fee(op, id);
+                       fc::variant r;
+                       fc::to_variant(op_fee, r, GRAPHENE_MAX_NESTED_OBJECTS);
+                       result.push_back(r);
+                   } else {
+                       result.push_back(helper.set_op_fees(op));
+                   }
+               } else {
+                   result.push_back(helper.set_op_fees(op));
+               }
           }
        }
 
@@ -1577,7 +1588,18 @@ vector< fc::variant > database_api_impl::get_required_fees( const vector<operati
            fc::to_variant(op_fee, r, GRAPHENE_MAX_NESTED_OBJECTS);
            result.push_back(r);
        } else {
-           result.push_back(helper.set_op_fees(op));
+           if (_db.head_block_time() > HARDFORK_1024_TIME) {
+               if (op.which() == operation::tag<contract_update_operation>::value) {
+                   auto op_fee = _db.get_update_contract_fee(op, id);
+                   fc::variant r;
+                   fc::to_variant(op_fee, r, GRAPHENE_MAX_NESTED_OBJECTS);
+                   result.push_back(r);
+               } else {
+                   result.push_back(helper.set_op_fees(op));
+               }
+           } else {
+               result.push_back(helper.set_op_fees(op));
+           }
        }
    }
 

--- a/libraries/app/database_api_impl.cpp
+++ b/libraries/app/database_api_impl.cpp
@@ -1552,18 +1552,7 @@ vector< fc::variant > database_api_impl::get_required_fees( const vector<operati
            if (op.which() == operation::tag<contract_call_operation>::value) {
                result.push_back(mock_fee);
            } else {
-               if (_db.head_block_time() > HARDFORK_1024_TIME) {
-                   if (op.which() == operation::tag<contract_update_operation>::value) {
-                       auto op_fee = _db.get_update_contract_fee(op, id);
-                       fc::variant r;
-                       fc::to_variant(op_fee, r, GRAPHENE_MAX_NESTED_OBJECTS);
-                       result.push_back(r);
-                   } else {
-                       result.push_back(helper.set_op_fees(op));
-                   }
-               } else {
-                   result.push_back(helper.set_op_fees(op));
-               }
+               result.push_back(helper.set_op_fees(op));
           }
        }
 
@@ -1588,15 +1577,12 @@ vector< fc::variant > database_api_impl::get_required_fees( const vector<operati
            fc::to_variant(op_fee, r, GRAPHENE_MAX_NESTED_OBJECTS);
            result.push_back(r);
        } else {
-           if (_db.head_block_time() > HARDFORK_1024_TIME) {
-               if (op.which() == operation::tag<contract_update_operation>::value) {
-                   auto op_fee = _db.get_update_contract_fee(op, id);
-                   fc::variant r;
-                   fc::to_variant(op_fee, r, GRAPHENE_MAX_NESTED_OBJECTS);
-                   result.push_back(r);
-               } else {
-                   result.push_back(helper.set_op_fees(op));
-               }
+           if (_db.head_block_time() > HARDFORK_1024_TIME &&
+               op.which() == operation::tag<contract_update_operation>::value) {
+               auto op_fee = _db.get_update_contract_fee(op, id);
+               fc::variant r;
+               fc::to_variant(op_fee, r, GRAPHENE_MAX_NESTED_OBJECTS);
+               result.push_back(r);
            } else {
                result.push_back(helper.set_op_fees(op));
            }

--- a/libraries/chain/contract_evaluator.cpp
+++ b/libraries/chain/contract_evaluator.cpp
@@ -126,7 +126,13 @@ void_result contract_update_evaluator::do_apply(const contract_update_operation 
         obj.code_version = code_hash;
         obj.abi = op.abi;
     });
-
+    if (d.head_block_time() > HARDFORK_1024_TIME) {
+        // overwrite contract_update_operation fee
+        asset fee = d.get_update_contract_fee(op, op.fee.asset_id);
+        generic_evaluator::prepare_fee(op.fee_payer(), fee, op);
+        generic_evaluator::convert_fee();
+        generic_evaluator::pay_fee();
+    }
     return void_result();
 } FC_CAPTURE_AND_RETHROW((op.owner)(op.contract)(op.fee)(op.abi)) }
 

--- a/libraries/chain/contract_evaluator.cpp
+++ b/libraries/chain/contract_evaluator.cpp
@@ -121,13 +121,6 @@ void_result contract_update_evaluator::do_apply(const contract_update_operation 
         obj.code_version = code_hash;
         obj.abi = op.abi;
     });
-    if (d.head_block_time() > HARDFORK_1024_TIME) {
-        // overwrite contract_update_operation fee
-        asset fee = d.get_update_contract_fee(op, op.fee.asset_id);
-        generic_evaluator::prepare_fee(op.fee_payer(), fee, op);
-        generic_evaluator::convert_fee();
-        generic_evaluator::pay_fee();
-    }
     return void_result();
 } FC_CAPTURE_AND_RETHROW((op.owner)(op.contract)(op.fee)(op.abi)) }
 

--- a/libraries/chain/contract_evaluator.cpp
+++ b/libraries/chain/contract_evaluator.cpp
@@ -88,9 +88,15 @@ void_result contract_update_evaluator::do_evaluate(const contract_update_operati
     if(d.head_block_time() > HARDFORK_1015_TIME) {
         FC_ASSERT(contract_obj.code.size() > 0, "can not update a normal account: ${a}", ("a", op.contract));
     }
-
-    code_hash = fc::sha256::hash(op.code);
-    FC_ASSERT(code_hash != contract_obj.code_version, "code not updated");
+    if (d.head_block_time() > HARDFORK_1024_TIME) {
+        auto new_abi_hash = fc::sha256::hash(op.abi);
+        auto old_abi_hash = fc::sha256::hash(contract_obj.abi);
+        code_hash = fc::sha256::hash(op.code);
+        FC_ASSERT(code_hash != contract_obj.code_version || new_abi_hash != old_abi_hash, "code not updated");
+    } else {
+        code_hash = fc::sha256::hash(op.code);
+        FC_ASSERT(code_hash != contract_obj.code_version, "code not updated");
+    }
 
     FC_ASSERT(op.code.size() > 0, "contract code cannot be empty");
 

--- a/libraries/chain/contract_evaluator.cpp
+++ b/libraries/chain/contract_evaluator.cpp
@@ -88,12 +88,7 @@ void_result contract_update_evaluator::do_evaluate(const contract_update_operati
     if(d.head_block_time() > HARDFORK_1015_TIME) {
         FC_ASSERT(contract_obj.code.size() > 0, "can not update a normal account: ${a}", ("a", op.contract));
     }
-    if (d.head_block_time() > HARDFORK_1024_TIME) {
-        auto new_abi_hash = fc::sha256::hash(op.abi);
-        auto old_abi_hash = fc::sha256::hash(contract_obj.abi);
-        code_hash = fc::sha256::hash(op.code);
-        FC_ASSERT(code_hash != contract_obj.code_version || new_abi_hash != old_abi_hash, "code not updated");
-    } else {
+    if (d.head_block_time() < HARDFORK_1024_TIME) {
         code_hash = fc::sha256::hash(op.code);
         FC_ASSERT(code_hash != contract_obj.code_version, "code not updated");
     }

--- a/libraries/chain/db_getter.cpp
+++ b/libraries/chain/db_getter.cpp
@@ -199,8 +199,9 @@ asset database::get_update_contract_fee( const operation& op, asset_id_type id )
         auto data_fee = cu_op.calculate_data_fee(newsize - oldsize, contract_update_operation::fee_parameters_type().price_per_kbyte);
         amount += data_fee;
     }
-    asset op_fee(amount, id);
-    op_fee = from_core_asset(to_core_asset(op_fee), id);
+    asset_id_type core_asset_id = current_core_asset_id();
+    asset op_fee(amount, core_asset_id);
+    op_fee = from_core_asset(op_fee, id);
     return op_fee;
 }
 

--- a/libraries/chain/db_getter.cpp
+++ b/libraries/chain/db_getter.cpp
@@ -180,5 +180,28 @@ asset database::from_core_asset(const asset &a, const asset_id_type &id)
         return asset(a.amount / uint64_t(pr.to_real()), id);
     }
 }
+asset database::get_update_contract_fee( const operation& op, asset_id_type id )
+{
+    fc::variant result;
+    FC_ASSERT(op.which() == operation::tag<contract_update_operation>::value, "get_update_contract_fee error: op type is not contract_update_operation");
+    const contract_update_operation &cu_op = op.get<contract_update_operation>();
+    auto &contract_account = cu_op.contract;
+    auto acc_idx = get_index_type<account_index>().indices();
+    auto itor = acc_idx.find(contract_account);
+    FC_ASSERT(itor != acc_idx.end(), "contract account is not exist");
+    auto oldsize = fc::raw::pack_size(itor->abi) + itor->code.size();
+    auto newsize = fc::raw::pack_size(cu_op.abi) + cu_op.code.size();
+    share_type amount;
+    if (oldsize >= newsize) {
+        amount = contract_update_operation::fee_parameters_type().fee;
+    } else {
+        amount = contract_update_operation::fee_parameters_type().fee;
+        auto data_fee = cu_op.calculate_data_fee(newsize - oldsize, contract_update_operation::fee_parameters_type().price_per_kbyte);
+        amount += data_fee;
+    }
+    asset op_fee(amount, id);
+    op_fee = from_core_asset(to_core_asset(op_fee), id);
+    return op_fee;
+}
 
 } }

--- a/libraries/chain/include/graphene/chain/database.hpp
+++ b/libraries/chain/include/graphene/chain/database.hpp
@@ -282,6 +282,8 @@ namespace graphene { namespace chain {
          const node_property_object&            get_node_properties()const;
          const fee_schedule&                    current_fee_schedule()const;
 
+         asset                                  get_update_contract_fee( const operation& op, asset_id_type id );
+
          time_point_sec   head_block_time()const;
          uint32_t         head_block_num()const;
          block_id_type    head_block_id()const;

--- a/libraries/chain/include/graphene/chain/evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/evaluator.hpp
@@ -152,21 +152,17 @@ namespace graphene { namespace chain {
          if (!trx_state->skip_fee_schedule_check
                  && (o.which() != operation::tag<pay_data_transaction_operation>::value)
                  && (o.which() != operation::tag<contract_call_operation>::value)) {
-             if (db().head_block_time() > HARDFORK_1024_TIME) {
-                 if (o.which() != operation::tag<contract_update_operation>::value) {
-                     share_type required_fee = calculate_fee_for_operation(op);
-                     GRAPHENE_ASSERT(core_fee_paid >= required_fee,
-                                     insufficient_fee,
-                                     "Insufficient Fee Paid",
-                                     ("core_fee_paid", core_fee_paid)("required", required_fee));
-                 }
+             share_type required_fee;
+             if (db().head_block_time() > HARDFORK_1024_TIME && o.which() == operation::tag<contract_update_operation>::value) {
+                 asset_id_type core_asset_id = db().current_core_asset_id();
+                 required_fee = db().get_update_contract_fee(op, core_asset_id).amount;
              } else {
-                 share_type required_fee = calculate_fee_for_operation(op);
-                 GRAPHENE_ASSERT(core_fee_paid >= required_fee,
-                                 insufficient_fee,
-                                 "Insufficient Fee Paid",
-                                 ("core_fee_paid", core_fee_paid)("required", required_fee));
+                 required_fee = calculate_fee_for_operation(op);
              }
+             GRAPHENE_ASSERT(core_fee_paid >= required_fee,
+                             insufficient_fee,
+                             "Insufficient Fee Paid",
+                             ("core_fee_paid", core_fee_paid)("required", required_fee));
          }
          return eval->do_evaluate(op);
       }

--- a/libraries/chain/include/graphene/chain/evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/evaluator.hpp
@@ -152,11 +152,21 @@ namespace graphene { namespace chain {
          if (!trx_state->skip_fee_schedule_check
                  && (o.which() != operation::tag<pay_data_transaction_operation>::value)
                  && (o.which() != operation::tag<contract_call_operation>::value)) {
-            share_type required_fee = calculate_fee_for_operation(op);
-            GRAPHENE_ASSERT( core_fee_paid >= required_fee,
-                       insufficient_fee,
-                       "Insufficient Fee Paid",
-                       ("core_fee_paid",core_fee_paid)("required", required_fee) );
+             if (db().head_block_time() > HARDFORK_1024_TIME) {
+                 if (o.which() != operation::tag<contract_update_operation>::value) {
+                     share_type required_fee = calculate_fee_for_operation(op);
+                     GRAPHENE_ASSERT(core_fee_paid >= required_fee,
+                                     insufficient_fee,
+                                     "Insufficient Fee Paid",
+                                     ("core_fee_paid", core_fee_paid)("required", required_fee));
+                 }
+             } else {
+                 share_type required_fee = calculate_fee_for_operation(op);
+                 GRAPHENE_ASSERT(core_fee_paid >= required_fee,
+                                 insufficient_fee,
+                                 "Insufficient Fee Paid",
+                                 ("core_fee_paid", core_fee_paid)("required", required_fee));
+             }
          }
          return eval->do_evaluate(op);
       }

--- a/libraries/chain/include/graphene/chain/hardfork.hpp
+++ b/libraries/chain/include/graphene/chain/hardfork.hpp
@@ -121,6 +121,11 @@
 #define HARDFORK_1023_TIME (fc::time_point_sec( 1555761600 )) // for testnet, 2019-04-20T12:00:00(UTC)
 #endif
 
+#ifndef HARDFORK_1024_TIME
+// for testnet after this time modify update_contract logic
+#define HARDFORK_1024_TIME (fc::time_point_sec( 1556625600 )) // for testnet, 2019-04-30T12:00:00(UTC)
+#endif
+
 // #413 Add operation to claim asset fees
 #ifndef HARDFORK_413_TIME
 #define HARDFORK_413_TIME (fc::time_point_sec( 1446652800 ))

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1114,7 +1114,13 @@
 
            signed_transaction tx;
            tx.operations.push_back(op);
-           set_operation_fees(tx, _remote_db->get_global_properties().parameters.current_fees, fee_asset_obj);
+           vector<fc::variant> fees = _remote_db->get_required_fees(tx.operations, fee_asset_obj->id);
+           asset fee;
+           fc::from_variant(fees[0], fee, GRAPHENE_MAX_NESTED_OBJECTS);
+           op.fee = fee;
+
+           tx.operations.clear();
+           tx.operations.push_back(op);
            tx.validate();
 
            return sign_transaction(tx, broadcast);


### PR DESCRIPTION
#160 更新智能合约逻辑

1.  更新合约，校验abi和code，只需任意一种不同，便可以更新。

2. 更新合约手续费调整：`base_fee + （new_size - old_size）* price_per_kbyte `，合约变小和合约大小不变，则只需支付base_fee。

`size差值 = (new_abi_size + new_code_size) - (old_abi_size + old_code_size)`