### PR TITLE
fix: fix query txid cmake with static link

### DIFF
--- a/libraries/plugins/query_txid/CMakeLists.txt
+++ b/libraries/plugins/query_txid/CMakeLists.txt
@@ -3,15 +3,22 @@ file(GLOB HEADERS "include/graphene/query_txid/*.hpp")
 add_library( graphene_query_txid
              query_txid_plugin.cpp
            )
+find_path(LevelDB_INCLUDE_PATH NAMES leveldb/db.h leveldb/write_batch.h)
+find_library(LevelDB_LIBRARY NAMES libleveldb.a)
+find_library(Snappy_LIBRARY NAMES libsnappy.a)
 
-target_link_libraries( graphene_query_txid graphene_chain graphene_app leveldb)
-target_include_directories( graphene_query_txid
-                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+if(LevelDB_INCLUDE_PATH AND LevelDB_LIBRARY AND Snappy_LIBRARY)
+   target_link_libraries( graphene_query_txid graphene_chain graphene_app ${LevelDB_LIBRARY} ${Snappy_LIBRARY})
+   target_include_directories( graphene_query_txid
+                              PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" ${LevelDB_INCLUDE_PATH})
+   install( TARGETS
+      graphene_query_txid
 
-install( TARGETS
-   graphene_query_txid
+      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION lib
+      ARCHIVE DESTINATION lib
+   )
+else(LevelDB_INCLUDE_PATH AND LevelDB_LIBRARY AND Snappy_LIBRARY)
+   message(FATAL_ERROR "You need leveldb and snappy")
+endif()
 
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
-)

--- a/libraries/plugins/query_txid/query_txid_plugin.cpp
+++ b/libraries/plugins/query_txid/query_txid_plugin.cpp
@@ -42,19 +42,19 @@ class query_txid_plugin_impl
     fc::signal<void()> sig_db_write;
     fc::signal<void(const uint64_t)> sig_remove;
 
-    static DB *leveldb;
+    static leveldb::DB *leveldb;
     void consume_block();                               //Consume block
     void remove_trx_index(const uint64_t trx_entry_id); //Remove trx_index in db
 };
-DB *query_txid_plugin_impl::leveldb = nullptr;
+leveldb::DB *query_txid_plugin_impl::leveldb = nullptr;
 
 void query_txid_plugin_impl::init()
 {
     try {
         //Create leveldb
-        Options options;
+        leveldb::Options options;
         options.create_if_missing = true;
-        Status s = DB::Open(options, db_path, &leveldb);
+        leveldb::Status s = leveldb::DB::Open(options, db_path, &leveldb);
 
         // Respond to the sig_db_write signale
         sig_db_write.connect([&]() { consume_block(); });


### PR DESCRIPTION
发现问题：由于带插件版本witness_node程序编译时，动态链接了leveldb库。所以在新的机器中运行时，需要安装leveldb环境。

修改：修改CMakeLists.txt，链接`libleveldb.a`和`libsnappy.a`静态库文件。