### PR TITLE
fix: fix codehash unassigned cause testnet repaly error

### DIFF
--- a/libraries/chain/contract_evaluator.cpp
+++ b/libraries/chain/contract_evaluator.cpp
@@ -88,8 +88,8 @@ void_result contract_update_evaluator::do_evaluate(const contract_update_operati
     if(d.head_block_time() > HARDFORK_1015_TIME) {
         FC_ASSERT(contract_obj.code.size() > 0, "can not update a normal account: ${a}", ("a", op.contract));
     }
+    code_hash = fc::sha256::hash(op.code);
     if (d.head_block_time() < HARDFORK_1024_TIME) {
-        code_hash = fc::sha256::hash(op.code);
         FC_ASSERT(code_hash != contract_obj.code_version, "code not updated");
     }
 


### PR DESCRIPTION
此错误导致测试网节点重放区块出现问题，并导致了节点mac版本不能同步的问题，错误 #187